### PR TITLE
Fix play/pause and skip animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@
 
 - Users and song tags page moved to settings page
 
+### Fixed
+
+- Animation of the play/pause and skip icons on the player.
+
 ## 1.1.0 - 2018-01-25
 
 ### Added

--- a/src/jsx/components/player/ManageButton.jsx
+++ b/src/jsx/components/player/ManageButton.jsx
@@ -1,0 +1,157 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import classNames from 'classnames'
+import { CSSTransitionLazy } from 'components/generics/ReactTransitionGroup'
+import { Status } from 'reducers/alterationsStatus'
+
+/**
+ * ManageButton class for a button connected to a player manage command
+ *
+ * This button plays a transition when the status of the manage command changes.
+ * The icon exit the button and re-enters. The button is somewhat protected during
+ * the exit transition, since the new status (or new icon) will be taken into
+ * account at the end of the exit transition, to be sure the icon exits
+ * gracefully.
+ *
+ * - manageStatus: when the status is pending, the button is in transition and
+ *      won't take account of the status untill the exit transition ends.
+ * - icon: icon to display on the button. If the icon changes, it will be taken
+ *      into account immediately if there is no transition or when the exit
+ *      transition ends.
+ * - disabled: disabled boolean.
+ * - iconDisabled: if disabled, the button use this icon if provided. Otherwise
+ *      use the normal one.
+ * - className: extra class to pass to the button.
+ * - timeout: duration of the transition. Default to 150 ms.
+ * - onClic: handle to pass to the button.
+ */
+export default class ManageButton extends Component {
+    static propTypes = {
+        manageStatus: PropTypes.symbol,
+        disabled: PropTypes.bool,
+        className: PropTypes.string,
+        timeout: PropTypes.number,
+        onClick: PropTypes.func.isRequired,
+        icon: PropTypes.string.isRequired,
+        iconDisabled: PropTypes.string,
+    }
+
+    static defaultProps = {
+        timeout: 150,
+    }
+
+    state = {
+        isLeaving: false,
+        display: true,
+        error: false,
+        icon: '',
+    }
+
+    componentDidUpdate(prevProps) {
+        // do not watch for udptates during the transition
+        if (this.state.isLeaving) return
+
+        const manageStatus = this.props.manageStatus
+        const prevManageStatus = prevProps.manageStatus
+
+        if (manageStatus !== prevManageStatus) {
+            if (manageStatus === Status.pending) {
+                // the status being pending means that the transition starts
+                this.setState({
+                    isLeaving: true,
+                    display: false,
+                    error: false,
+                })
+
+                // udpate the state after the transition duration
+                // we can't directly use the CSSTransition `onExit` and
+                // `onExited` attributes, because this leads to modify the state
+                // within the render and is anti-pattern
+                this.transitionEndedTimeout = setTimeout(
+                    this.transitionEndedFunc,
+                    this.props.timeout
+                )
+            } else {
+                // if the request took more time than the timeout, the display is
+                // reactivated when ready
+                this.setState({
+                    display: true,
+                    error: manageStatus === Status.failed,
+                })
+            }
+        }
+
+        const icon = this.props.icon
+        const prevIcon = prevProps.icon
+
+        if (icon !== prevIcon) {
+            // if the icon has changed (not during the transition), update it
+            this.setState({icon})
+        }
+    }
+
+    transitionEndedFunc = () => {
+        // this callback unsets the transition state and sets the display to its
+        // current state
+        // if the request has not finished, the display is reset in
+        // `componentDidUpdate`
+        const { manageStatus, icon } = this.props
+        this.setState({
+            isLeaving: false,
+            display: manageStatus !== Status.pending,
+            error: manageStatus === Status.failed,
+            icon,
+        })
+    }
+
+    componentWillUnmount() {
+        // clear the state update
+        clearTimeout(self.transitionEndedTimeout)
+    }
+
+    componentWillMount() {
+        // set the first icon
+        const { icon } = this.props
+        this.setState({icon})
+    }
+
+    render() {
+        const { manageStatus, onClick, disabled, className, timeout, iconDisabled } = this.props
+
+        const onClickControlled = (e) => {
+            // do not manage any other click during the transition
+            // since there is a delay between the click and the update of the
+            // state, one can click the button more than once…
+            if (this.state.isLeaving) return
+            onClick(e)
+        }
+
+        // if the button is disabled, use the disabled icon
+        const icon = disabled ?
+            iconDisabled || this.state.icon :
+            this.state.icon
+
+        return (
+            <button
+                className={classNames(
+                    'control',
+                    'primary',
+                    className,
+                    {'managed-error': this.state.error},
+                )}
+                onClick={onClickControlled}
+                disabled={disabled}
+            >
+                <CSSTransitionLazy
+                    in={this.state.display}
+                    classNames="managed"
+                    timeout={timeout}
+                >
+                    <span className="managed icon">
+                        <i className={`fa fa-${icon}`}></i>
+                    </span>
+                </CSSTransitionLazy>
+            </button>
+        )
+    }
+}

--- a/src/jsx/components/player/ManageButton.jsx
+++ b/src/jsx/components/player/ManageButton.jsx
@@ -11,7 +11,7 @@ import { Status } from 'reducers/alterationsStatus'
  * The icon exit the button and re-enters. The button is somewhat protected during
  * the exit transition, since the new status (or new icon) will be taken into
  * account at the end of the exit transition, to be sure the icon exits
- * gracefully.
+ * gracefully. This is done by using the state of the component.
  *
  * - manageStatus: when the status is pending, the button is in transition and
  *      won't take account of the status untill the exit transition ends.
@@ -23,7 +23,7 @@ import { Status } from 'reducers/alterationsStatus'
  *      use the normal one.
  * - className: extra class to pass to the button.
  * - timeout: duration of the transition. Default to 150 ms.
- * - onClic: handle to pass to the button.
+ * - onClick: handle to pass to the button.
  */
 export default class ManageButton extends Component {
     static propTypes = {
@@ -127,6 +127,8 @@ export default class ManageButton extends Component {
         }
 
         // if the button is disabled, use the disabled icon
+        // if there is no disabled icon, use the normal one
+        // use the normal one if the button is not disabled as well
         const icon = disabled ?
             iconDisabled || this.state.icon :
             this.state.icon

--- a/src/jsx/components/player/Player.jsx
+++ b/src/jsx/components/player/Player.jsx
@@ -2,16 +2,13 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
 import PropTypes from 'prop-types'
-import { CSSTransition, TransitionGroup } from 'react-transition-group'
 import { CSSTransitionLazy } from 'components/generics/ReactTransitionGroup'
-import classNames from 'classnames'
 import { formatDuration, formatTime, params } from 'utils'
 import Song from 'components/song/Song'
 import UserWidget from 'components/generics/UserWidget'
 import { IsPlaylistManagerOrOwner } from 'components/permissions/Playlist'
 import { loadPlayerDigest, sendPlayerCommands } from 'actions/player'
 import Playlist from './playlist/List'
-import { Status } from 'reducers/alterationsStatus'
 import PlayerNotification from './Notification'
 import { playerDigestPropType, playerCommandsPropType } from 'reducers/player'
 import ManageButton from './ManageButton'
@@ -44,11 +41,6 @@ class Player extends Component {
     render() {
         const { status: playerStatus, manage: playerCommand, errors: playerErrors } = this.props.playerDigest.data
         const { fetchError } = this.props.playerDigest
-        let song
-        let songData
-        let playlistEntryOwner
-        let duration
-        let progress
         const isPlaying = !!playerStatus.playlist_entry
         const controlDisabled = !isPlaying || fetchError
         const commandPauseStatus = this.props.commands.pause.status
@@ -58,13 +50,14 @@ class Player extends Component {
          * Song display if any song is currently playing
          */
 
+        let song
+        let playlistEntryOwner
+        let duration
+        let progress
         if (isPlaying){
-            song = playerStatus.playlist_entry.song
-            duration = playerStatus.playlist_entry.song.duration
-
-            songData = (
+            song = (
                     <Song
-                        song={song}
+                        song={playerStatus.playlist_entry.song}
                         noDuration
                         noTag
                         />
@@ -77,7 +70,8 @@ class Player extends Component {
                     />
                 )
 
-            progress = playerStatus.timing * 100 / duration;
+            duration = playerStatus.playlist_entry.song.duration
+            progress = Math.min(playerStatus.timing * 100 / duration, 100)
         } else {
             progress = 0
             duration = 0
@@ -121,7 +115,7 @@ class Player extends Component {
                             </IsPlaylistManagerOrOwner>
                         </div>
                         <div className="song-container notifiable">
-                            {songData}
+                            {song}
                             {playlistEntryOwner}
                             <div className="song-timing">
                                 <div className="current">

--- a/src/jsx/components/player/Player.jsx
+++ b/src/jsx/components/player/Player.jsx
@@ -98,7 +98,7 @@ class Player extends Component {
                                         this.props.sendPlayerCommands({pause: !playerCommand.pause})
                                     }}
                                     disabled={controlDisabled}
-                                    icon={playerCommand.pause ? 'pause' : 'play'}
+                                    icon={playerCommand.pause ? 'play' : 'pause'}
                                     iconDisabled="stop"
                                 />
                             </IsPlaylistManagerOrOwner>


### PR DESCRIPTION
This was due to the fact that the play/pause and skip alteration status change from pending to something else (successful or failed) before the exit transition ends. This PR solves the problem by using a `ManageButton` component that will keep the alteration status until the exit transition ends and update it right after it.

This also helps to clean the `Player` component.