### PR TITLE
Fix wrong selection color

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,9 @@
+const autoprefixer = require('autoprefixer');
+
 module.exports = {
     plugins: [
-        require('autoprefixer')
+        autoprefixer({
+            remove: false, // do not seek outdated prefixes
+        }),
     ]
 }

--- a/src/less/components/all.less
+++ b/src/less/components/all.less
@@ -18,11 +18,9 @@ mark {
 }
 
 // selection highlighting
-* {
-    &::selection {
-        background: @brand-primary;
-        color: @text-dark;
-    }
+::selection {
+    background: @brand-primary;
+    color: @text-dark;
 }
 
 // make headers thin and marginless

--- a/src/less/components/navigation/error_page.less
+++ b/src/less/components/navigation/error_page.less
@@ -25,9 +25,7 @@
         color: @brand-danger-darker;
     }
 
-    * {
-        &::selection {
-            background: @brand-danger;
-        }
+    ::selection {
+        background: @brand-danger;
     }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,9 +9,11 @@ module.exports = {
   module: {
     rules: [
       {
-          loader: "babel-loader",
           test: /\.jsx?$/,
-          include: path.resolve(__dirname, 'src/jsx')
+          exclude: /node_modules/,
+          use: {
+              loader: "babel-loader",
+          }
       },
       {
           test: /\.less$/,
@@ -46,7 +48,7 @@ module.exports = {
   },
   output: {
     filename: "dakara.js",
-    path: path.resolve(__dirname, 'dist')
+    path: path.resolve('dist')
   },
   plugins: [
       new ExtractTextPlugin("dakara.css")

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,6 @@ module.exports = {
       {
           test: /\.less$/,
           exclude: /node_modules/,
-          include: path.resolve(__dirname, 'src/less'),
           use: ExtractTextPlugin.extract({
               fallback: 'style-loader',
               use: [
@@ -27,10 +26,7 @@ module.exports = {
                       }
                   },
                   {
-                      loader: 'postcss-loader',
-                      options: {
-                          remove: false, // do not seek outdated prefixes
-                      }
+                      loader: 'postcss-loader'
                   },
                   {
                       loader: 'less-loader'


### PR DESCRIPTION
Related to #72.

It appears that the wrong option was passed to the PostCSS loader, instead of Autoprefixer, and that made PostCSS to not work at all. The option is now handled correctly and the use of `::selection` has been corrected among the LESS files.

The Webpack configuration file has been a bit refreshed (suppression of some `include` keys).