### PR TITLE
Make work link type name hard coded

### DIFF
--- a/src/jsx/actions/playlist.js
+++ b/src/jsx/actions/playlist.js
@@ -163,7 +163,7 @@ export const addSongToPlaylist = (songId) => ({
     [FETCH_API]: {
             endpoint: `${baseUrl}playlist/entries/`,
             method: 'POST',
-            json: {song: songId},
+            json: {song_id: songId},
             types: [
                 ALTERATION_REQUEST,
                 ALTERATION_SUCCESS,

--- a/src/jsx/components/song/WorkLink.jsx
+++ b/src/jsx/components/song/WorkLink.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import Highlighter from 'react-highlight-words'
 import HighlighterQuery from 'components/generics/HighlighterQuery'
 import PropTypes from 'prop-types'
+import { WorkLinkName } from 'reducers/library'
 import { workLinkPropType } from 'serverPropTypes/library'
 
 /**
@@ -37,7 +38,7 @@ export default class WorkLink extends Component {
         // Link type
         const linkType = (
                 <span className="link-type">
-                    {longLinkType ? workLink.link_type_name : workLink.link_type}
+                    {longLinkType ? WorkLinkName[workLink.link_type] : workLink.link_type}
                 </span>
         )
 

--- a/src/jsx/reducers/library.js
+++ b/src/jsx/reducers/library.js
@@ -11,6 +11,17 @@ import { updateData } from 'utils'
  */
 
 /**
+ * Work link complete name
+ */
+
+export const WorkLinkName = Object.freeze({
+    OP: "Opening",
+    ED: "Ending",
+    IN: "Insert song",
+    IS: "Image song",
+})
+
+/**
  * Generators for library content
  */
 

--- a/src/jsx/serverPropTypes/library.js
+++ b/src/jsx/serverPropTypes/library.js
@@ -21,7 +21,6 @@ export const workPropType = PropTypes.shape({
 
 export const workLinkPropType = PropTypes.shape({
     work: workPropType.isRequired,
-    link_type_name: PropTypes.string.isRequired,
     link_type_number: PropTypes.number,
     link_type: PropTypes.string.isRequired,
     episodes: PropTypes.string,


### PR DESCRIPTION
This PR follows the changes induced in [this PR on the server](https://github.com/DakaraProject/dakara-server/pull/62).

Long name of the link type is now hard-coded. The key `song_id` is used when adding a song to the playlist instead of `song`.