### PR TITLE
Add package lock to bump version

### DIFF
--- a/bump_version.sh
+++ b/bump_version.sh
@@ -18,7 +18,7 @@ sed -i "/^## Unreleased$/a \\
 \\
 ## $version_number - $version_date" $changelog_file
 
-git add package.json $changelog_file
+git add package.json package-lock.json $changelog_file
 git commit -m "Version $version_number"
 git tag $version_number
 


### PR DESCRIPTION
package-lock.json version was updated by npm version command, but not added to commit