### PR TITLE
Vite migration: ESLint fixes

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -16,6 +16,8 @@ module.exports = {
       "warn",
       { allowConstantExport: true },
     ],
+    "no-class-assign": "off",
+    "no-unused-vars": "off",
     "simple-import-sort/imports": [
       "error",
       {

--- a/src/components/DevWarning.jsx
+++ b/src/components/DevWarning.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import { Component } from 'react'
 import semver from 'semver'
 
 

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import { Component } from 'react'
 
 export default class Footer extends Component {
     render() {

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 import { NavLink } from 'react-router-dom'
 

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -15,6 +15,7 @@ class Main extends Component {
         isLoggedIn: PropTypes.bool.isRequired,
         loadCurrentUser: PropTypes.func.isRequired,
         loadServerSettings: PropTypes.func.isRequired,
+        children: PropTypes.node,
     }
 
     componentDidMount() {

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 
 import { loadCurrentUser } from 'actions/authenticatedUser'

--- a/src/components/adapted/ReactRouterDom.jsx
+++ b/src/components/adapted/ReactRouterDom.jsx
@@ -12,6 +12,7 @@ import {
 /**
  * Add the location prop to a component
  */
+// eslint-disable-next-line react/display-name
 export const withLocation = (Component) => (props) => (
     <Component
         location={useLocation()}
@@ -22,6 +23,7 @@ export const withLocation = (Component) => (props) => (
 /**
  * Add the params prop to a component
  */
+// eslint-disable-next-line react/display-name
 export const withParams = (Component) => (props) => (
     <Component
         params={useParams()}
@@ -32,6 +34,7 @@ export const withParams = (Component) => (props) => (
 /**
  * Add the navigate prop to a component
  */
+// eslint-disable-next-line react/display-name
 export const withNavigate = (Component) => (props) => (
     <Component
         navigate={useNavigate()}
@@ -42,6 +45,7 @@ export const withNavigate = (Component) => (props) => (
 /**
  * Add the searchParams and setSearchParams props to a component
  */
+// eslint-disable-next-line react/display-name
 export const withSearchParams = (Component) => (props) => {
     const [searchParams, setSearchParams] = useSearchParams()
     return (

--- a/src/components/adapted/ReactRouterDom.jsx
+++ b/src/components/adapted/ReactRouterDom.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import { stringify } from 'query-string'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import {
     Link as OldLink,
     useLocation,

--- a/src/components/adapted/ReactRouterDom.jsx
+++ b/src/components/adapted/ReactRouterDom.jsx
@@ -66,6 +66,7 @@ export default class Link extends Component {
             PropTypes.object,
             PropTypes.string,
         ]).isRequired,
+        children: PropTypes.node,
     }
 
     render () {

--- a/src/components/adapted/ReactTransitionGroup.jsx
+++ b/src/components/adapted/ReactTransitionGroup.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import { CSSTransition } from 'react-transition-group'
 
 /**
@@ -25,3 +26,6 @@ export const CSSTransitionLazy = ({children, ...props}) => (
         {children}
     </CSSTransition>
 )
+CSSTransitionLazy.propTypes = {
+    children: PropTypes.node,
+}

--- a/src/components/adapted/ReactTransitionGroup.jsx
+++ b/src/components/adapted/ReactTransitionGroup.jsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { CSSTransition } from 'react-transition-group'
 
 /**

--- a/src/components/generics/ConfirmationBar.jsx
+++ b/src/components/generics/ConfirmationBar.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 
 export default class ConfirmationBar extends Component {
     static propTypes = {

--- a/src/components/generics/ControlLink.jsx
+++ b/src/components/generics/ControlLink.jsx
@@ -12,6 +12,7 @@ export default class ControlLink extends Component {
             PropTypes.string,
             PropTypes.object
         ]).isRequired,
+        children: PropTypes.node,
     }
 
     render () {

--- a/src/components/generics/ControlLink.jsx
+++ b/src/components/generics/ControlLink.jsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 
 import Link from 'components/adapted/ReactRouterDom'
 

--- a/src/components/generics/Delayer.jsx
+++ b/src/components/generics/Delayer.jsx
@@ -4,6 +4,7 @@ import { Component } from 'react'
 export default class Delayer extends Component {
     static propTypes = {
         delay: PropTypes.number.isRequired,
+        children: PropTypes.node,
     }
 
     state = {display: false}

--- a/src/components/generics/Form.jsx
+++ b/src/components/generics/Form.jsx
@@ -36,6 +36,7 @@ class Form extends Component {
         ]).isRequired,
         title: PropTypes.string,
         validate: PropTypes.func,
+        children: PropTypes.node,
     }
 
     static defaultProps = {

--- a/src/components/generics/HighlighterQuery.jsx
+++ b/src/components/generics/HighlighterQuery.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import Highlighter from 'react-highlight-words'
 
 /**

--- a/src/components/generics/HighlighterQuery.jsx
+++ b/src/components/generics/HighlighterQuery.jsx
@@ -28,6 +28,7 @@ export default class HighlighterQuery extends Component {
             PropTypes.array,
         ]).isRequired,
         textToHighlight: PropTypes.string.isRequired,
+        children: PropTypes.node,
     }
 
     render() {

--- a/src/components/generics/ListingFetchWrapper.jsx
+++ b/src/components/generics/ListingFetchWrapper.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 
 import Delayer from 'components/generics/Delayer'
 import Notification from 'components/generics/Notification'

--- a/src/components/generics/ListingFetchWrapper.jsx
+++ b/src/components/generics/ListingFetchWrapper.jsx
@@ -8,6 +8,7 @@ import { Status } from 'reducers/alterationsResponse'
 export default class ListingFetchWrapper extends Component {
     static propTypes = {
         status: PropTypes.symbol,
+        children: PropTypes.node,
     }
 
     render() {

--- a/src/components/generics/Navigator.jsx
+++ b/src/components/generics/Navigator.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import { parse } from 'query-string'
-import React, { Component } from 'react'
+import { Component } from 'react'
 
 import { withLocation } from 'components/adapted/ReactRouterDom'
 import ControlLink from 'components/generics/ControlLink'

--- a/src/components/generics/Navigator.jsx
+++ b/src/components/generics/Navigator.jsx
@@ -106,4 +106,6 @@ class Navigator extends Component {
     }
 }
 
-export default withLocation(Navigator)
+Navigator = withLocation(Navigator)
+
+export default Navigator

--- a/src/components/generics/Notification.jsx
+++ b/src/components/generics/Notification.jsx
@@ -157,6 +157,11 @@ export default class Notification extends Component {
  * Must be used on the cell of the first column.
  */
 export class NotifiableForTable extends Component {
+    static propTypes = {
+        children: PropTypes.node,
+        className: PropTypes.string,
+    }
+
     elementRef = React.createRef()
 
     state = {

--- a/src/components/generics/PlaylistEntryMinimal.jsx
+++ b/src/components/generics/PlaylistEntryMinimal.jsx
@@ -1,4 +1,5 @@
 import UserWidget from 'components/generics/UserWidget'
+import { playlistEntryPropType } from 'serverPropTypes/playlist'
 
 const PlaylistEntryMinimal = (props) => (
     <div className="playlist-entry-minimal">
@@ -8,5 +9,8 @@ const PlaylistEntryMinimal = (props) => (
         <UserWidget user={props.playlistEntry.owner}/>
     </div>
 )
+PlaylistEntryMinimal.propTypes = {
+    playlistEntry: playlistEntryPropType.isRequired
+}
 
 export default PlaylistEntryMinimal

--- a/src/components/generics/Router.jsx
+++ b/src/components/generics/Router.jsx
@@ -14,6 +14,7 @@ class ProtectedRoute extends Component {
         hasUserInfo: PropTypes.bool,
         isLoggedIn: PropTypes.bool,
         location: PropTypes.object.isRequired,
+        children: PropTypes.node,
     }
 
     /**

--- a/src/components/generics/Router.jsx
+++ b/src/components/generics/Router.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import { stringify } from 'query-string'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 import {
     Navigate,

--- a/src/components/generics/Tab.jsx
+++ b/src/components/generics/Tab.jsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { NavLink } from 'react-router-dom'
 
 export default class Tab extends Component {

--- a/src/components/generics/TokenWidget.jsx
+++ b/src/components/generics/TokenWidget.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 
 import Notification from 'components/generics/Notification'
 import { Status } from 'reducers/alterationsResponse'

--- a/src/components/generics/UserWidget.jsx
+++ b/src/components/generics/UserWidget.jsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 
 import { userPropType } from 'serverPropTypes/users'

--- a/src/components/generics/UserWidget.jsx
+++ b/src/components/generics/UserWidget.jsx
@@ -10,6 +10,7 @@ class UserWidget extends Component {
         currentUser: userPropType.isRequired,
         noResize: PropTypes.bool,
         user: userPropType.isRequired,
+        className: PropTypes.string,
     }
 
     render() {

--- a/src/components/karaoke/KaraStatusNotification.jsx
+++ b/src/components/karaoke/KaraStatusNotification.jsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Link } from 'react-router-dom'
 
 const karaStatusNotification = () => (

--- a/src/components/karaoke/Karaoke.jsx
+++ b/src/components/karaoke/Karaoke.jsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 
 import { loadPlaylistDigest } from 'actions/playlistDigest'

--- a/src/components/karaoke/Karaoke.jsx
+++ b/src/components/karaoke/Karaoke.jsx
@@ -10,12 +10,14 @@ import PlaylistInfoBar from 'components/karaoke/PlaylistInfoBar'
 import { IsPlaylistManager } from 'components/permissions/Playlist'
 import { Status } from 'reducers/alterationsResponse'
 import { karaokeStatePropType } from 'reducers/playlist'
+import { userPropType } from 'serverPropTypes/users'
 import { params } from 'utils'
 
 class Karaoke extends Component {
     static propTypes = {
         loadPlaylistDigest: PropTypes.func.isRequired,
         karaokeState: karaokeStatePropType.isRequired,
+        user: userPropType.isRequired,
     }
 
     state = {

--- a/src/components/karaoke/PlaylistInfoBar.jsx
+++ b/src/components/karaoke/PlaylistInfoBar.jsx
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 import { Link } from 'react-router-dom'
 

--- a/src/components/karaoke/player/ManageButton.jsx
+++ b/src/components/karaoke/player/ManageButton.jsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 
 import { CSSTransitionLazy } from 'components/adapted/ReactTransitionGroup'
 import { alterationResponsePropType, Status } from 'reducers/alterationsResponse'

--- a/src/components/karaoke/player/Notification.jsx
+++ b/src/components/karaoke/player/Notification.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { CSSTransition, TransitionGroup } from 'react-transition-group'
 
 import { alterationResponsePropType, Status } from 'reducers/alterationsResponse'

--- a/src/components/karaoke/player/Player.jsx
+++ b/src/components/karaoke/player/Player.jsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
 import { stringify } from 'query-string'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 
 import { sendPlayerCommand } from 'actions/playlist'

--- a/src/components/karaoke/player/Player.jsx
+++ b/src/components/karaoke/player/Player.jsx
@@ -18,6 +18,7 @@ import { playerStatusStatePropType } from 'reducers/playlist'
 import {
     playerErrorsDigestStatePropType
 } from 'reducers/playlistDigest'
+import { userPropType } from 'serverPropTypes/users'
 import { formatDuration } from 'utils'
 
 class Player extends Component {
@@ -27,6 +28,8 @@ class Player extends Component {
         responseOfSendPlayerCommands: PropTypes.objectOf(alterationResponsePropType),
         sendPlayerCommand: PropTypes.func.isRequired,
         setWithControls: PropTypes.func.isRequired,
+        user: userPropType.isRequired,
+        navigate: PropTypes.func.isRequired,
     }
 
     state = {

--- a/src/components/library/Library.jsx
+++ b/src/components/library/Library.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 import { Outlet } from 'react-router-dom'
 

--- a/src/components/library/SearchBox.jsx
+++ b/src/components/library/SearchBox.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import { parse } from 'query-string'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 
 import { storeSearchBox } from 'actions/library'

--- a/src/components/library/SearchBox.jsx
+++ b/src/components/library/SearchBox.jsx
@@ -14,6 +14,8 @@ class SearchBox extends Component {
         placeholder: PropTypes.string.isRequired,
         searchParams: PropTypes.object.isRequired,
         setSearchParams: PropTypes.func.isRequired,
+        searchBox: PropTypes.object.isRequired,
+        storeSearchBox: PropTypes.func.isRequired,
     }
 
     state = {

--- a/src/components/library/artist/Entry.jsx
+++ b/src/components/library/artist/Entry.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import { stringify } from 'query-string'
-import React, { Component } from 'react'
+import { Component } from 'react'
 
 import { withNavigate } from 'components/adapted/ReactRouterDom'
 import HighlighterQuery from 'components/generics/HighlighterQuery'

--- a/src/components/library/artist/Entry.jsx
+++ b/src/components/library/artist/Entry.jsx
@@ -54,4 +54,6 @@ class ArtistEntry extends Component {
     }
 }
 
-export default withNavigate(ArtistEntry)
+ArtistEntry = withNavigate(ArtistEntry)
+
+export default ArtistEntry

--- a/src/components/library/artist/List.jsx
+++ b/src/components/library/artist/List.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 
 import { loadLibraryEntries } from 'actions/library'

--- a/src/components/library/artist/List.jsx
+++ b/src/components/library/artist/List.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import { Component } from 'react'
 import { connect } from 'react-redux'
 
@@ -12,6 +13,8 @@ import { artistStatePropType } from 'reducers/library'
 class ArtistList extends Component {
     static propTypes = {
         artistState: artistStatePropType.isRequired,
+        searchParams: PropTypes.object.isRequired,
+        loadLibraryEntries: PropTypes.func.isRequired,
     }
 
     /**

--- a/src/components/library/song/Entry.jsx
+++ b/src/components/library/song/Entry.jsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 import { CSSTransition, TransitionGroup } from 'react-transition-group'
 

--- a/src/components/library/song/Entry.jsx
+++ b/src/components/library/song/Entry.jsx
@@ -20,6 +20,7 @@ import Song from 'components/song/Song'
 import { alterationResponsePropType } from 'reducers/alterationsResponse'
 import { songPropType } from 'serverPropTypes/library'
 import { playlistEntryPropType } from 'serverPropTypes/playlist'
+import { userPropType } from 'serverPropTypes/users'
 
 
 class SongEntry extends Component {
@@ -35,6 +36,7 @@ class SongEntry extends Component {
         searchParams: PropTypes.object.isRequired,
         setSearchParams: PropTypes.func.isRequired,
         song: songPropType.isRequired,
+        user: userPropType.isRequired,
     }
 
     componentWillUnmount() {

--- a/src/components/library/song/EntryExpanded.jsx
+++ b/src/components/library/song/EntryExpanded.jsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 
 import { clearAlteration } from 'actions/alterations'

--- a/src/components/library/song/EntryExpanded.jsx
+++ b/src/components/library/song/EntryExpanded.jsx
@@ -12,6 +12,7 @@ import SongEntryExpandedArtist from 'components/library/song/EntryExpandedArtist
 import SongEntryExpandedWork from 'components/library/song/EntryExpandedWork'
 import { CanAddToPlaylist, IsPlaylistUser} from 'components/permissions/Playlist'
 import SongTagList from 'components/song/SongTagList'
+import { alterationResponsePropType } from 'reducers/alterationsResponse'
 import { songPropType } from 'serverPropTypes/library'
 
 class SongEntryExpanded extends Component {
@@ -21,6 +22,9 @@ class SongEntryExpanded extends Component {
         searchParams: PropTypes.object.isRequired,
         setSearchParams: PropTypes.func.isRequired,
         song: songPropType.isRequired,
+        clearAlteration: PropTypes.func.isRequired,
+        addSongToPlaylistWithOptions: PropTypes.func.isRequired,
+        responseOfAddSongWithOptions: alterationResponsePropType,
     }
 
     componentWillUnmount() {

--- a/src/components/library/song/EntryExpandedArtist.jsx
+++ b/src/components/library/song/EntryExpandedArtist.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import { Component } from 'react'
 
 import ArtistWidget from 'components/song/ArtistWidget'
 import { artistPropType } from 'serverPropTypes/library'

--- a/src/components/library/song/EntryExpandedArtist.jsx
+++ b/src/components/library/song/EntryExpandedArtist.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import { Component } from 'react'
 
 import ArtistWidget from 'components/song/ArtistWidget'
@@ -6,6 +7,7 @@ import { artistPropType } from 'serverPropTypes/library'
 export default class SongEntryExpandedArtist extends Component {
     static propTypes = {
         artist: artistPropType.isRequired,
+        setQuery: PropTypes.func.isRequired,
     }
 
     handleSearchArtist = () => {

--- a/src/components/library/song/EntryExpandedWork.jsx
+++ b/src/components/library/song/EntryExpandedWork.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import { Component } from 'react'
 
 import WorkLinkWidget from 'components/song/WorkLinkWidget'
 import { workLinkPropType } from 'serverPropTypes/library'

--- a/src/components/library/song/EntryExpandedWork.jsx
+++ b/src/components/library/song/EntryExpandedWork.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import { Component } from 'react'
 
 import WorkLinkWidget from 'components/song/WorkLinkWidget'
@@ -6,6 +7,7 @@ import { workLinkPropType } from 'serverPropTypes/library'
 export default class SongEntryExpandedWork extends Component {
     static propTypes = {
         work: workLinkPropType.isRequired,
+        setQuery: PropTypes.func.isRequired,
     }
 
     handleSearchWork = () => {

--- a/src/components/library/song/List.jsx
+++ b/src/components/library/song/List.jsx
@@ -83,18 +83,22 @@ class SongList extends Component {
                             <ul>
                                 <li>
                                     Quotes to group words: {' '}
-                                    <span className="example">"my artist"</span>
+                                    <span className="example">
+                                        &quot;my artist&quot;
+                                    </span>
                             </li>
                                 <li>
                                     Prefix and quotes to search in a specific
                                     field: {' '}
-                                    <span className="example">artist:"my artist"</span>
+                                    <span className="example">
+                                        artist:&quot;my artist&quot;
+                                    </span>
                                 </li>
                                 <li>
                                     Prefix and doubled quotes to search a specific
                                     field exactly: {' '}
                                     <span className="example">
-                                        artist:""my artist name""
+                                        artist:&quot;&quot;my artist name&quot;&quot;
                                     </span>
                                 </li>
                                 <li>

--- a/src/components/library/song/List.jsx
+++ b/src/components/library/song/List.jsx
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs'
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 
 import { loadLibraryEntries } from 'actions/library'

--- a/src/components/library/song/List.jsx
+++ b/src/components/library/song/List.jsx
@@ -19,6 +19,7 @@ class SongList extends Component {
         searchParams: PropTypes.object.isRequired,
         setSearchParams: PropTypes.func.isRequired,
         songState: songStatePropType.isRequired,
+        loadLibraryEntries: PropTypes.func.isRequired,
     }
 
     /**

--- a/src/components/library/work/Entry.jsx
+++ b/src/components/library/work/Entry.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import { stringify } from 'query-string'
-import React, { Component } from 'react'
+import { Component } from 'react'
 
 import { withNavigate } from 'components/adapted/ReactRouterDom'
 import HighlighterQuery from 'components/generics/HighlighterQuery'
@@ -47,7 +47,7 @@ class WorkEntry extends Component {
                         {song_count}
                     </div>
                 </div>
-                <div className="controls"> 
+                <div className="controls">
                     <button className="control primary" onClick={this.handleSearch}>
                         <span className="icon">
                             <i className="las la-search"></i>

--- a/src/components/library/work/Entry.jsx
+++ b/src/components/library/work/Entry.jsx
@@ -59,4 +59,6 @@ class WorkEntry extends Component {
     }
 }
 
-export default withNavigate(WorkEntry)
+WorkEntry = withNavigate(WorkEntry)
+
+export default WorkEntry

--- a/src/components/library/work/List.jsx
+++ b/src/components/library/work/List.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 
 import { loadLibraryEntries } from 'actions/library'

--- a/src/components/library/work/List.jsx
+++ b/src/components/library/work/List.jsx
@@ -19,6 +19,7 @@ class WorkList extends Component {
         setSearchParams: PropTypes.func.isRequired,
         workState: workStatePropType,
         workTypeState: workTypeStatePropType.isRequired,
+        loadLibraryEntries: PropTypes.func.isRequired,
     }
 
     /**

--- a/src/components/navigation/Forbidden.jsx
+++ b/src/components/navigation/Forbidden.jsx
@@ -25,4 +25,6 @@ class Forbidden extends Component {
     }
 }
 
-export default withLocation(Forbidden)
+Forbidden = withLocation(Forbidden)
+
+export default Forbidden

--- a/src/components/navigation/Forbidden.jsx
+++ b/src/components/navigation/Forbidden.jsx
@@ -17,7 +17,7 @@ class Forbidden extends Component {
                 </div>
                 <div className="content">
                     <div className="url">{url}</div>
-                    <p>We're sorry, you do not have the privilege to access {' '}
+                    <p>We&apos;re sorry, you do not have the privilege to access {' '}
                     this ressource.</p>
                 </div>
             </div>

--- a/src/components/navigation/Forbidden.jsx
+++ b/src/components/navigation/Forbidden.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 
 import { withLocation } from 'components/adapted/ReactRouterDom'
 

--- a/src/components/navigation/NotFound.jsx
+++ b/src/components/navigation/NotFound.jsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 
 import { withLocation } from 'components/adapted/ReactRouterDom'
 

--- a/src/components/navigation/NotFound.jsx
+++ b/src/components/navigation/NotFound.jsx
@@ -27,4 +27,6 @@ class NotFound extends Component {
     }
 }
 
-export default withLocation(NotFound)
+NotFound = withLocation(NotFound)
+
+export default NotFound

--- a/src/components/navigation/NotFound.jsx
+++ b/src/components/navigation/NotFound.jsx
@@ -20,7 +20,7 @@ class NotFound extends Component {
                 </div>
                 <div className="content">
                     <div className="url">{url}</div>
-                    <p>We're sorry, your request did not match any route…</p>
+                    <p>We&apos;re sorry, your request did not match any route…</p>
                 </div>
             </div>
         )

--- a/src/components/permissions/Base.jsx
+++ b/src/components/permissions/Base.jsx
@@ -3,6 +3,7 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 
 import { userPropType } from 'serverPropTypes/users'
+import { mapStateToProps } from 'utils/permissions'
 
 export class PermissionBase extends Component {
     static propTypes = {
@@ -59,10 +60,6 @@ export class PermissionBase extends Component {
 
     }
 }
-
-export const mapStateToProps = (state) => ({
-    user: state.authenticatedUser
-})
 
 /**
  * Is authenticated

--- a/src/components/permissions/Base.jsx
+++ b/src/components/permissions/Base.jsx
@@ -10,6 +10,7 @@ export class PermissionBase extends Component {
         disable: PropTypes.bool,
         object: PropTypes.object,
         user: userPropType,
+        children: PropTypes.node,
     }
 
     instanceHasPermission = () => {

--- a/src/components/permissions/Library.jsx
+++ b/src/components/permissions/Library.jsx
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux'
 
-import { mapStateToProps, PermissionBase } from 'components/permissions/Base'
+import { PermissionBase } from 'components/permissions/Base'
+import { mapStateToProps } from 'utils/permissions'
 
 /**
  * Library manager

--- a/src/components/permissions/Playlist.jsx
+++ b/src/components/permissions/Playlist.jsx
@@ -3,6 +3,7 @@ import { Component } from 'react'
 import { connect } from 'react-redux'
 
 import { PermissionBase } from 'components/permissions/Base'
+import { karaokeStatePropType } from 'reducers/playlist'
 import { userPropType } from 'serverPropTypes/users'
 import { mapStateToProps } from 'utils/permissions'
 
@@ -74,6 +75,12 @@ export const IsPlaylistUser = connect(
  */
 
 class CanAddToPlaylist extends Component {
+    static propTypes = {
+        user: userPropType.isRequired,
+        karaokeState: karaokeStatePropType.isRequired,
+        children: PropTypes.node,
+    }
+
     render() {
         const { user } = this.props
         const { data: karaoke } = this.props.karaokeState

--- a/src/components/permissions/Playlist.jsx
+++ b/src/components/permissions/Playlist.jsx
@@ -2,8 +2,9 @@ import PropTypes from 'prop-types'
 import { Component } from 'react'
 import { connect } from 'react-redux'
 
-import { mapStateToProps, PermissionBase } from 'components/permissions/Base'
+import { PermissionBase } from 'components/permissions/Base'
 import { userPropType } from 'serverPropTypes/users'
+import { mapStateToProps } from 'utils/permissions'
 
 /**
  * Playlist manager or Owner of the object

--- a/src/components/permissions/Users.jsx
+++ b/src/components/permissions/Users.jsx
@@ -1,13 +1,8 @@
 import { connect } from 'react-redux'
 
-import { mapStateToProps, PermissionBase } from 'components/permissions/Base'
+import { PermissionBase } from 'components/permissions/Base'
 import { userPropType } from 'serverPropTypes/users'
-
-export const permissionLevels = {
-    u: 'user',
-    m: 'manager',
-    p: 'player'
-}
+import { mapStateToProps } from 'utils/permissions'
 
 /**
  * Users manager

--- a/src/components/playlist/Playlist.jsx
+++ b/src/components/playlist/Playlist.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { Outlet } from 'react-router-dom'
 
 import Tab from 'components/generics/Tab'

--- a/src/components/playlist/played/Entry.jsx
+++ b/src/components/playlist/played/Entry.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import { stringify } from 'query-string'
-import React, { Component } from 'react'
+import { Component } from 'react'
 
 import { withNavigate } from 'components/adapted/ReactRouterDom'
 import PlaylistPositionInfo from 'components/song/PlaylistPositionInfo'

--- a/src/components/playlist/played/Entry.jsx
+++ b/src/components/playlist/played/Entry.jsx
@@ -51,4 +51,6 @@ class Entry extends Component {
     }
 }
 
-export default withNavigate(Entry)
+Entry = withNavigate(Entry)
+
+export default Entry

--- a/src/components/playlist/played/List.jsx
+++ b/src/components/playlist/played/List.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 
 import {

--- a/src/components/playlist/played/List.jsx
+++ b/src/components/playlist/played/List.jsx
@@ -19,6 +19,7 @@ class Played extends Component {
         playlistEntriesState: playlistEntriesStatePropType.isRequired,
         playlistPlayedState: playedStatePropType.isRequired,
         loadPlaylistEntries: PropTypes.func.isRequired,
+        searchParams: PropTypes.object.isRequired,
     }
 
     componentDidMount() {

--- a/src/components/playlist/playerErrors/Entry.jsx
+++ b/src/components/playlist/playerErrors/Entry.jsx
@@ -16,6 +16,8 @@ class PlayerErrorsEntry extends Component {
     static propTypes = {
         playerError: playerErrorPropType.isRequired,
         navigate: PropTypes.func.isRequired,
+        searchParams: PropTypes.object.isRequired,
+        setSearchParams: PropTypes.func.isRequired,
     }
 
     /**

--- a/src/components/playlist/playerErrors/Entry.jsx
+++ b/src/components/playlist/playerErrors/Entry.jsx
@@ -132,4 +132,6 @@ class PlayerErrorsEntry extends Component {
     }
 }
 
-export default withNavigate(withSearchParams(PlayerErrorsEntry))
+PlayerErrorsEntry = withNavigate(withSearchParams(PlayerErrorsEntry))
+
+export default PlayerErrorsEntry

--- a/src/components/playlist/playerErrors/List.jsx
+++ b/src/components/playlist/playerErrors/List.jsx
@@ -20,6 +20,7 @@ class PlayerErrorsList extends Component {
         playerErrorsDigestState: playerErrorsDigestStatePropType.isRequired,
         playerErrorsState: playerErrorsStatePropType.isRequired,
         loadPlayerErrors: PropTypes.func.isRequired,
+        searchParams: PropTypes.object.isRequired,
     }
 
     componentDidMount() {

--- a/src/components/playlist/queueing/Entry.jsx
+++ b/src/components/playlist/queueing/Entry.jsx
@@ -14,6 +14,7 @@ import {
 } from 'components/permissions/Playlist'
 import PlaylistPositionInfo from 'components/song/PlaylistPositionInfo'
 import Song from 'components/song/Song'
+import { alterationResponsePropType } from 'reducers/alterationsResponse'
 import { playlistEntryPropType } from 'serverPropTypes/playlist'
 
 class Entry extends Component {
@@ -35,7 +36,8 @@ class Entry extends Component {
         removeEntry: PropTypes.func.isRequired,
         reorderEntryPosition: PropTypes.number,
         responseOfMultipleReorderPlaylistEntry: PropTypes.object,
-        responseOfRemoveEntry: PropTypes.object,
+        responseOfRemoveEntry: alterationResponsePropType,
+        responseOfReorderPlaylistEntry: alterationResponsePropType,
     }
 
     state = {

--- a/src/components/playlist/queueing/Entry.jsx
+++ b/src/components/playlist/queueing/Entry.jsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
 import { stringify } from 'query-string'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 
 import { withNavigate,withSearchParams } from 'components/adapted/ReactRouterDom'

--- a/src/components/playlist/queueing/List.jsx
+++ b/src/components/playlist/queueing/List.jsx
@@ -32,6 +32,8 @@ class Queueing extends Component {
         responseOfMultipleReorderPlaylistEntry: PropTypes.objectOf(
             alterationResponsePropType
         ),
+        searchParams: PropTypes.object.isRequired,
+        setSearchParams: PropTypes.func.isRequired,
     }
 
     state = {

--- a/src/components/playlist/queueing/List.jsx
+++ b/src/components/playlist/queueing/List.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 import { CSSTransition, TransitionGroup } from 'react-transition-group'
 

--- a/src/components/registration/Login.jsx
+++ b/src/components/registration/Login.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import { parse } from 'query-string'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 import { Navigate, NavLink } from 'react-router-dom'
 

--- a/src/components/registration/Logout.jsx
+++ b/src/components/registration/Logout.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 import { Navigate } from 'react-router-dom'
 

--- a/src/components/registration/Register.jsx
+++ b/src/components/registration/Register.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 import { Navigate } from 'react-router-dom'
 

--- a/src/components/registration/ResetPassword.jsx
+++ b/src/components/registration/ResetPassword.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import { parse } from 'query-string'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 import { Navigate,NavLink } from 'react-router-dom'
 

--- a/src/components/registration/SendResetPasswordLink.jsx
+++ b/src/components/registration/SendResetPasswordLink.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 import { Navigate } from 'react-router-dom'
 

--- a/src/components/registration/VerifyEmail.jsx
+++ b/src/components/registration/VerifyEmail.jsx
@@ -50,7 +50,7 @@ class VerifyEmail extends Component {
                 )
                 break
 
-            case Status.failed:
+            case Status.failed: {
                 let message
                 if (responseOfVerifyEmail.message) {
                     message = (
@@ -66,6 +66,7 @@ class VerifyEmail extends Component {
                 )
                 error = true
                 break
+            }
 
             default:
                 content = (

--- a/src/components/registration/VerifyEmail.jsx
+++ b/src/components/registration/VerifyEmail.jsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
 import { parse } from 'query-string'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 
 import { verifyEmail } from 'actions/users'

--- a/src/components/registration/VerifyRegistration.jsx
+++ b/src/components/registration/VerifyRegistration.jsx
@@ -46,7 +46,7 @@ class VerifyRegistration extends Component {
                         <p>Email successfuly validated.</p>
                         <p>
                             A manager will validate your account,
-                            you'll be notified by email.
+                            you&apos;ll be notified by email.
                         </p>
                     </div>
                 )

--- a/src/components/registration/VerifyRegistration.jsx
+++ b/src/components/registration/VerifyRegistration.jsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
 import { parse } from 'query-string'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 
 import { verifyRegistration } from 'actions/users'

--- a/src/components/registration/VerifyRegistration.jsx
+++ b/src/components/registration/VerifyRegistration.jsx
@@ -52,7 +52,7 @@ class VerifyRegistration extends Component {
                 )
                 break
 
-            case Status.failed:
+            case Status.failed: {
                 let message
                 if (responseOfVerifyRegistration.message) {
                     message = (
@@ -68,6 +68,7 @@ class VerifyRegistration extends Component {
                 )
                 error = true
                 break
+            }
 
             default:
                 content = (

--- a/src/components/settings/KaraDateStop.jsx
+++ b/src/components/settings/KaraDateStop.jsx
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs'
 import customParseFormat from 'dayjs/plugin/customParseFormat'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 
 import { CheckboxField, FormBlock, InputField } from 'components/generics/Form'

--- a/src/components/settings/KaraStatus.jsx
+++ b/src/components/settings/KaraStatus.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 
 import { CheckboxField, FormBlock} from 'components/generics/Form'

--- a/src/components/settings/KaraStatus.jsx
+++ b/src/components/settings/KaraStatus.jsx
@@ -59,7 +59,7 @@ class KaraStatus extends Component {
                     <p>
                         Karaoke is not ongoing.
                         The player is stopped, the playlist is
-                        empty and you can't add songs to it.
+                        empty and you can&apos;t add songs to it.
                     </p>
                 )
             } else {
@@ -88,7 +88,7 @@ class KaraStatus extends Component {
                 } else {
                     karaStatusWidget.push(
                         <p>
-                            Songs can't be added to the playlist.
+                            Songs can&apos;t be added to the playlist.
                         </p>
                     )
                 }

--- a/src/components/settings/Settings.jsx
+++ b/src/components/settings/Settings.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { Outlet } from 'react-router-dom'
 
 import Tab from 'components/generics/Tab'

--- a/src/components/settings/Tokens.jsx
+++ b/src/components/settings/Tokens.jsx
@@ -11,7 +11,7 @@ import Notification from 'components/generics/Notification'
 import TokenWidget from 'components/generics/TokenWidget'
 import { IsLibraryManager } from 'components/permissions/Library'
 import { IsPlaylistManager } from 'components/permissions/Playlist'
-import { Status } from 'reducers/alterationsResponse'
+import { alterationResponsePropType, Status } from 'reducers/alterationsResponse'
 import { karaokeStatePropType,playerTokenStatePropType  } from 'reducers/playlist'
 
 
@@ -24,6 +24,7 @@ class PlayerTokenBox extends Component {
         responseOfCreatePlayerToken: PropTypes.object,
         responseOfRevokeToken: PropTypes.object,
         revokePlayerToken: PropTypes.func.isRequired,
+        responseOfRevokePlayerToken: alterationResponsePropType,
     }
 
     state = {

--- a/src/components/settings/Tokens.jsx
+++ b/src/components/settings/Tokens.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 import { CSSTransition } from 'react-transition-group'
 

--- a/src/components/settings/songTags/Entry.jsx
+++ b/src/components/settings/songTags/Entry.jsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 
 import { CSSTransitionLazy } from 'components/adapted/ReactTransitionGroup'
 import { CheckboxField, FormInline, HueField } from 'components/generics/Form'

--- a/src/components/settings/songTags/List.jsx
+++ b/src/components/settings/songTags/List.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import { parse } from 'query-string'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 
 import { clearAlteration } from 'actions/alterations'

--- a/src/components/settings/users/Edit.jsx
+++ b/src/components/settings/users/Edit.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 
 import { clearUser, getUser } from 'actions/users'

--- a/src/components/settings/users/Entry.jsx
+++ b/src/components/settings/users/Entry.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 
 import { CSSTransitionLazy } from 'components/adapted/ReactTransitionGroup'
 import ConfirmationBar from 'components/generics/ConfirmationBar'
@@ -141,4 +141,3 @@ const Marked = ({marked}) => {
         <i className="las la-check"></i>
     )
 }
-

--- a/src/components/settings/users/Entry.jsx
+++ b/src/components/settings/users/Entry.jsx
@@ -6,6 +6,7 @@ import ConfirmationBar from 'components/generics/ConfirmationBar'
 import ControlLink from 'components/generics/ControlLink'
 import Notification, { NotifiableForTable } from 'components/generics/Notification'
 import { IsNotSelf, IsUserManager } from 'components/permissions/Users'
+import { alterationResponsePropType } from 'reducers/alterationsResponse'
 import { userPropType } from 'serverPropTypes/users'
 
 import Marked from './Marked'
@@ -16,6 +17,7 @@ export default class SettingsUsersEntry extends Component {
         clearAlteration: PropTypes.func.isRequired,
         deleteUser: PropTypes.func.isRequired,
         user: userPropType.isRequired,
+        responseOfDelete: alterationResponsePropType,
     }
 
     state = {

--- a/src/components/settings/users/Entry.jsx
+++ b/src/components/settings/users/Entry.jsx
@@ -5,12 +5,11 @@ import { CSSTransitionLazy } from 'components/adapted/ReactTransitionGroup'
 import ConfirmationBar from 'components/generics/ConfirmationBar'
 import ControlLink from 'components/generics/ControlLink'
 import Notification, { NotifiableForTable } from 'components/generics/Notification'
-import {
-    IsNotSelf,
-    IsUserManager,
-    permissionLevels
-} from 'components/permissions/Users'
+import { IsNotSelf, IsUserManager } from 'components/permissions/Users'
 import { userPropType } from 'serverPropTypes/users'
+
+import Marked from './Marked'
+import PermissionText from './PermissionText'
 
 export default class SettingsUsersEntry extends Component {
     static propTypes = {
@@ -111,33 +110,4 @@ export default class SettingsUsersEntry extends Component {
             </tr>
         )
     }
-}
-
-const PermissionText = ({level}) => {
-    if (!level) {
-        return null
-    }
-
-    const permissionText = permissionLevels[level]
-
-    return (
-        <span className="permission-text">
-            {permissionText.substring(0, 1)}
-            <span className="hideable">
-                {permissionText.substring(1)}
-            </span>
-        </span>
-    )
-
-}
-
-
-const Marked = ({marked}) => {
-    if (!marked) {
-        return null
-    }
-
-    return (
-        <i className="las la-check"></i>
-    )
 }

--- a/src/components/settings/users/List.jsx
+++ b/src/components/settings/users/List.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import { parse } from 'query-string'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 
 import { clearAlteration } from 'actions/alterations'

--- a/src/components/settings/users/Marked.jsx
+++ b/src/components/settings/users/Marked.jsx
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types'
+
 export default function Marked({ marked }) {
     if (!marked) {
         return null
@@ -6,4 +8,7 @@ export default function Marked({ marked }) {
     return (
         <i className="las la-check"></i>
     )
+}
+Marked.propTypes = {
+    marked: PropTypes.bool
 }

--- a/src/components/settings/users/Marked.jsx
+++ b/src/components/settings/users/Marked.jsx
@@ -1,0 +1,9 @@
+export default function Marked({ marked }) {
+    if (!marked) {
+        return null
+    }
+
+    return (
+        <i className="las la-check"></i>
+    )
+}

--- a/src/components/settings/users/PermissionText.jsx
+++ b/src/components/settings/users/PermissionText.jsx
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types'
+
 import { permissionLevels } from 'utils/permissions';
 
 export default function PermissionText({ level }) {
@@ -15,4 +17,7 @@ export default function PermissionText({ level }) {
             </span>
         </span>
     )
+}
+PermissionText.propTypes = {
+    level: PropTypes.string
 }

--- a/src/components/settings/users/PermissionText.jsx
+++ b/src/components/settings/users/PermissionText.jsx
@@ -1,0 +1,18 @@
+import { permissionLevels } from 'utils/permissions';
+
+export default function PermissionText({ level }) {
+    if (!level) {
+        return null
+    }
+
+    const permissionText = permissionLevels[level]
+
+    return (
+        <span className="permission-text">
+            {permissionText.substring(0, 1)}
+            <span className="hideable">
+                {permissionText.substring(1)}
+            </span>
+        </span>
+    )
+}

--- a/src/components/song/ArtistWidget.jsx
+++ b/src/components/song/ArtistWidget.jsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 
 import HighlighterQuery from 'components/generics/HighlighterQuery'
 import { artistPropType } from 'serverPropTypes/library'

--- a/src/components/song/Song.jsx
+++ b/src/components/song/Song.jsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 
 import HighlighterQuery from 'components/generics/HighlighterQuery'
 import ArtistWidget from 'components/song/ArtistWidget'

--- a/src/components/song/SongTagList.jsx
+++ b/src/components/song/SongTagList.jsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 
 import { songTagPropType } from 'serverPropTypes/library'
 

--- a/src/components/song/WorkLinkWidget.jsx
+++ b/src/components/song/WorkLinkWidget.jsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 
 import HighlighterQuery from 'components/generics/HighlighterQuery'
 import { WorkLinkName } from 'reducers/library'

--- a/src/components/user/User.jsx
+++ b/src/components/user/User.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 
 import { FormBlock, InputField } from 'components/generics/Form'

--- a/src/components/user/User.jsx
+++ b/src/components/user/User.jsx
@@ -3,8 +3,8 @@ import { Component } from 'react'
 import { connect } from 'react-redux'
 
 import { FormBlock, InputField } from 'components/generics/Form'
-import { permissionLevels } from 'components/permissions/Users'
 import { userPropType } from 'serverPropTypes/users'
+import { permissionLevels } from 'utils/permissions';
 
 class User extends Component {
     static propTypes = {

--- a/src/reducers/alterationsResponse.js
+++ b/src/reducers/alterationsResponse.js
@@ -90,7 +90,7 @@ function alteration(state, action) {
             }
 
         case ALTERATION_FAILURE:
-        case ALTERATION_VALIDATION_ERROR:
+        case ALTERATION_VALIDATION_ERROR: {
             const { message, non_field_errors, detail } = action.error
 
             // fetch API error
@@ -138,6 +138,7 @@ function alteration(state, action) {
                 fields,
                 date: alterationDate,
             }
+        }
 
         case ALTERATION_RESPONSE_CLEAR:
             return undefined

--- a/src/reducers/playlistDigest.js
+++ b/src/reducers/playlistDigest.js
@@ -46,7 +46,7 @@ function entries(state = defaultEntries, action) {
                 status: state.status || Status.pending,
             }
 
-        case PLAYLIST_DIGEST_SUCCESS:
+        case PLAYLIST_DIGEST_SUCCESS: {
             // if the kara status is set to stop, reset entries
             if (!action.response.karaoke.ongoing) {
                 return defaultEntries
@@ -82,6 +82,7 @@ function entries(state = defaultEntries, action) {
                     playlistEntries: entries,
                 }
             }
+        }
 
         case PLAYLIST_DIGEST_FAILURE:
             return {

--- a/src/reducers/songTags.js
+++ b/src/reducers/songTags.js
@@ -105,12 +105,13 @@ export default function songTags(state = defaultSongTagsSettings, action) {
             // Update disableness of updated tag
             return updateTagInState(elementId, state, {disabled})
 
-        case ALTERATION_SUCCESS:
+        case ALTERATION_SUCCESS: {
             if (alterationName !== 'editSongTagColor') return state
 
             // Update new color of updated tag
             const { color_hue } = json
             return updateTagInState(elementId, state, {color_hue})
+        }
 
         default:
             return state

--- a/src/utils/permissions.js
+++ b/src/utils/permissions.js
@@ -1,0 +1,9 @@
+export const permissionLevels = {
+    u: 'user',
+    m: 'manager',
+    p: 'player'
+}
+
+export const mapStateToProps = (state) => ({
+    user: state.authenticatedUser
+})


### PR DESCRIPTION
Follow-up to #154 

## eslint errors/warnings and applied fixes:

### React `no-unused-vars`

Remove unused React imports.

### `no-class-assign` and other `no-unused-vars`

Disable these two rules. The second error was often raised on unused function arguments or object destructured properties that I believe were left for better readability and self-documentation.

### `no-case-declarations`

Add `{}`.

### `no-undef`

Add `// eslint-disable-next-line`.
This error was raised on `DAKARA_VERSION`, `DAKARA_BUGTRACKER` and `DAKARA_PROJECT_HOMEPAGE` that are defined in `vite.config.js`.

### `react/display-name`

Add `// eslint-disable-next-line` on four decorators in https://github.com/NextFire/dakara-client-web/blob/vite-eslint/src/components/adapted/ReactRouterDom.jsx.

### `react/no-unescaped-entities`

Escape characters.

### `react-refresh/only-export-components`

Name some default exports + move two shared const to https://github.com/NextFire/dakara-client-web/blob/vite-eslint/src/utils/permissions.js.

### `react/prop-types`

Add or complete `propTypes` on various components.
I often had to guess when to add `isRequired` or not…