### PR TITLE
Update create_archive script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,9 +33,8 @@
    ```
 6. Call the script to create the archive:
    ```sh
-   ./create_archive.sh 0.0.0
+   ./create_archive.sh
    ```
-   with the according version number.
 7. On GitHub, draft a new release, set the version number with the created tag ("Existing tag" should read).
    Set the release title with "Version 0.0.0" (with number, you get it?).
    Copy-paste corresponding section of the changelog file in the release description.

--- a/create_archive.sh
+++ b/create_archive.sh
@@ -14,7 +14,7 @@ npm run build
 # Go to build directory
 cd build
 
-# Move index.html and robots.txt to static dir
+# Copy index.html and robots.txt to static dir
 cp index.html robots.txt static
 
 # archive the static folder

--- a/create_archive.sh
+++ b/create_archive.sh
@@ -4,28 +4,21 @@
 set -e
 
 # version
-if [[ -z $1 ]]
-then
-    >&2 echo 'Error: no version specified'
-    exit 1
-fi
-
-version_number=$1
-archive_name=dakara-client-web_$version_number.zip
+version="$(npm pkg get version | sed 's/"//g')"
+archive_name="dakara-client-web_$version.zip"
 
 # make production build
 echo "Creating build, please wait..."
 npm run build
 
-
 # Go to build directory
 cd build
 
-# Move index.html to static dir
-mv index.html static
+# Move index.html and robots.txt to static dir
+cp index.html robots.txt static
 
 # archive the static folder
-zip -r ../"$archive_name" static
+zip -r "../$archive_name" static
 
 echo "Archive created in $archive_name"
 


### PR DESCRIPTION
The script does not need to explicitly pass the version number, it gets it from `nmp` directly.