### PR TITLE
Build in `dist/static`

### DIFF
--- a/create_archive.sh
+++ b/create_archive.sh
@@ -11,7 +11,9 @@ archive_name="dakara-client-web_$version.zip"
 echo "Creating build, please wait..."
 npm run build
 
+cd dist
+
 # archive the dist folder
-zip -r "$archive_name" dist
+zip -r "../$archive_name" static
 
 echo "Archive created in $archive_name"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build --outDir dist/static",
     "lint": "eslint src --ext .js,.jsx",
     "stylelint": "stylelint ./src/style/**/*.{css,scss}",
     "preview": "vite preview"


### PR DESCRIPTION
It makes more sense for the build to present as a `static` directory, so this PR goes in that way.