### PR TITLE
Allow clickable elements to focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Allow any clickable element to focus.
+
 ## 1.9.0 - 2025-03-06
 
 ### Added
@@ -41,7 +45,7 @@
 
 - Played and queuing playlist entries can be accessed in a library fashion (using pagination).
 - Allow to reorder a queing playlist entry to the top or to the bottom of the playlist.
-- Do not highlight rows on focus (only on hover), focus buttons instead.
+- Do not highlight rows on focus (only on hover).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 
 - Played and queuing playlist entries can be accessed in a library fashion (using pagination).
 - Allow to reorder a queing playlist entry to the top or to the bottom of the playlist.
-- Do not highlight rows on focus (only on hover).
+- Do not highlight rows on focus (only on hover), focus buttons instead.
 
 ### Removed
 

--- a/src/components/karaoke/player/Player.jsx
+++ b/src/components/karaoke/player/Player.jsx
@@ -155,8 +155,8 @@ class Player extends Component {
                 <div className="player-info">
                     <div className="playlist-entry">
                         {useInstrumental}
-                        <div
-                            className="entry-info"
+                        <button
+                            className="entry-info transparent"
                             onClick={() => {
                                 this.handleSearch(song)
                             }}
@@ -180,7 +180,7 @@ class Player extends Component {
                                 ))}
                             </div>
                             <UserWidget user={owner} noResize />
-                        </div>
+                        </button>
                     </div>
                     <div className="timing">
                         <div className="current">

--- a/src/components/library/SearchBox.jsx
+++ b/src/components/library/SearchBox.jsx
@@ -73,7 +73,7 @@ class SearchBox extends Component {
         let helpBox
         if (help) {
             helpButton = (
-                <button className="control" onClick={e => {
+                <button className="control transparent" onClick={e => {
                     this.toggleHelp()
                 }}>
                     <span className="icon">
@@ -137,12 +137,16 @@ class SearchBox extends Component {
                                 />
                                 <div className="controls">
                                     {helpButton}
-                                    <button className="control" onClick={e => {
-                                            this.setState({query: ''})
-                                            // clear query string
-                                            this.props.setSearchParams({})
+                                    <button
+                                        className="control transparent"
+                                        onClick={
+                                            e => {
+                                                this.setState({query: ''})
+                                                // clear query string
+                                                this.props.setSearchParams({})
+                                            }
                                         }
-                                    }>
+                                  >
                                         <span className="icon">
                                             <i className="las la-times"></i>
                                         </span>

--- a/src/components/library/SearchBox.jsx
+++ b/src/components/library/SearchBox.jsx
@@ -73,13 +73,13 @@ class SearchBox extends Component {
         let helpBox
         if (help) {
             helpButton = (
-                <div className="control" onClick={e => {
+                <button className="control" onClick={e => {
                     this.toggleHelp()
                 }}>
                     <span className="icon">
                         <i className="las la-question-circle"></i>
                     </span>
-                </div>
+                </button>
             )
 
             helpBox = (
@@ -137,7 +137,7 @@ class SearchBox extends Component {
                                 />
                                 <div className="controls">
                                     {helpButton}
-                                    <div className="control" onClick={e => {
+                                    <button className="control" onClick={e => {
                                             this.setState({query: ''})
                                             // clear query string
                                             this.props.setSearchParams({})
@@ -146,7 +146,7 @@ class SearchBox extends Component {
                                         <span className="icon">
                                             <i className="las la-times"></i>
                                         </span>
-                                    </div>
+                                    </button>
                                 </div>
                             </div>
                         </div>

--- a/src/components/library/song/Entry.jsx
+++ b/src/components/library/song/Entry.jsx
@@ -99,7 +99,7 @@ class SongEntry extends Component {
                 >
                     <div className="library-entry-song-compact hoverizable notifiable">
                         <button
-                            className="expander"
+                            className="expander transparent"
                             onClick={
                                 () => expanded ?
                                     this.setExpanded() :

--- a/src/components/library/song/Entry.jsx
+++ b/src/components/library/song/Entry.jsx
@@ -98,18 +98,22 @@ class SongEntry extends Component {
                     )}
                 >
                     <div className="library-entry-song-compact hoverizable notifiable">
-                        <Song
-                            song={song}
-                            query={query}
-                            noArtistWork={expanded}
-                            noTag={expanded}
-                            karaokeRemainingSeconds={karaokeRemainingSeconds}
-                            handleClick={
+                        <button
+                            className="expander"
+                            onClick={
                                 () => expanded ?
                                     this.setExpanded() :
                                     this.setExpanded(song.id)
                             }
-                        />
+                        >
+                            <Song
+                                song={song}
+                                query={query}
+                                noArtistWork={expanded}
+                                noTag={expanded}
+                                karaokeRemainingSeconds={karaokeRemainingSeconds}
+                            />
+                        </button>
                         <div className="extra">
                             <TransitionGroup
                                 className="play-queue-info-wrapper"

--- a/src/components/playlist/played/Entry.jsx
+++ b/src/components/playlist/played/Entry.jsx
@@ -36,10 +36,14 @@ class Entry extends Component {
                 }
             >
                 <div className="library-entry-song-compact">
-                    <Song
-                        song={entry.song}
-                        handleClick={this.handleSearch}
-                    />
+                    <button
+                        className="expander transparent"
+                        onClick={() => this.handleSearch()}
+                    >
+                        <Song
+                            song={entry.song}
+                        />
+                    </button>
                     <div className="extra">
                         <PlaylistPositionInfo
                             entryPlayed={entry}

--- a/src/components/playlist/playerErrors/Entry.jsx
+++ b/src/components/playlist/playerErrors/Entry.jsx
@@ -72,16 +72,20 @@ class PlayerErrorsEntry extends Component {
                         'hoverizable'
                     }
                 >
-                    <Song
-                        song={entry.song}
-                        handleClick={
+                    <button
+                        className="expander transparent"
+                        onClick={
                             () => {
                                 expanded ?
                                     this.setExpanded() :
                                     this.setExpanded(playerError.id)
                             }
                         }
-                    />
+                    >
+                        <Song
+                            song={entry.song}
+                        />
+                    </button>
                     <div className="extra">
                         <PlaylistPositionInfo
                             entryPlayed={entry}

--- a/src/components/playlist/queueing/Entry.jsx
+++ b/src/components/playlist/queueing/Entry.jsx
@@ -127,10 +127,14 @@ class Entry extends Component {
                 {delayed: this.props.responseOfRemoveEntry}
             )}>
                 <div className="library-entry-song-compact notifiable">
-                    <Song
-                        song={entry.song}
-                        handleClick={this.handleSearch}
-                    />
+                    <button
+                        className="expander transparent"
+                        onClick={() => this.handleSearch()}
+                    >
+                        <Song
+                            song={entry.song}
+                        />
+                    </button>
                     <div className="extra">
                         <PlaylistPositionInfo
                             entryQueuing={playlistEntries.find(e => e.id === entry.id)}

--- a/src/style/base/_common.scss
+++ b/src/style/base/_common.scss
@@ -15,20 +15,6 @@ body {
     padding: 0;
 }
 
-// links
-a {
-    color: colors.$brand-primary-light;
-    text-decoration: underline;
-
-    &:hover:not(:focus) {
-        color: colors.$brand-primary-lighter;
-    }
-
-    &:focus {
-        color: colors.$brand-primary-lighter;
-    }
-}
-
 // highlight tag
 mark {
     background: colors.$brand-primary;
@@ -62,6 +48,20 @@ h3 {
 
 p {
     @include fonts.make-long;
+
+    // links
+    a {
+        color: colors.$brand-primary-light;
+        text-decoration: underline;
+
+        &:hover:not(:focus) {
+            color: colors.$brand-primary-lighter;
+        }
+
+        &:focus {
+            color: colors.$brand-primary-lighter;
+        }
+    }
 }
 
 ul {

--- a/src/style/base/_common.scss
+++ b/src/style/base/_common.scss
@@ -19,6 +19,14 @@ body {
 a {
     color: colors.$brand-primary-light;
     text-decoration: underline;
+
+    &:hover:not(:focus) {
+        color: colors.$brand-primary-lighter;
+    }
+
+    &:focus {
+        color: colors.$brand-primary-lighter;
+    }
 }
 
 // highlight tag

--- a/src/style/base/_controls.scss
+++ b/src/style/base/_controls.scss
@@ -4,6 +4,8 @@
 // Controls style file
 //
 
+@use "sass:color";
+
 @use "~/abstracts/colors";
 @use "~/abstracts/controls";
 @use "~/abstracts/sizes";
@@ -47,7 +49,7 @@
         }
 
         // maker for different type of control buttons
-        @mixin make-control($color-enabled, $color-disabled, $color-activated) {
+        @mixin make-control($color-enabled, $color-disabled, $color-hover, $color-focus: $color-hover) {
             background: $color-enabled;
 
             &.disabled,
@@ -56,10 +58,16 @@
                 cursor: default;
             }
 
-            // this rule is weaker than the rule for even lines, so it
-            // has to be enforced manually
-            &:not(.disabled):not([disabled]):hover {
-                background: $color-activated !important;
+            &:not(.disabled):not([disabled]) {
+                // this rule is weaker than the rule for even lines, so it
+                // has to be enforced manually
+                &:hover:not(:focus) {
+                    background: $color-hover;
+                }
+
+                &:focus {
+                    background: color.adjust($color-focus, $lightness: 10%);
+                }
             }
         }
 
@@ -96,7 +104,9 @@
 .sublisting-entry:nth-child(even) .controls.subcontrols {
     .control {
         @mixin make-control-line-even($color-normal, $color-disabled) {
-            background: $color-normal;
+            &:not(:hover):not(:focus) {
+                background: $color-normal;
+            }
 
             &.disabled,
             &[disabled] {
@@ -131,7 +141,7 @@
 .hoverizable:hover .controls:not(:hover) {
     .control {
         @mixin make-control-line-hover($color-normal, $color-disabled) {
-            &:not(.disabled):not([disabled]) {
+            &:not(.disabled):not([disabled]):not(:focus) {
                 background: $color-normal;
             }
 

--- a/src/style/base/_controls.scss
+++ b/src/style/base/_controls.scss
@@ -4,8 +4,6 @@
 // Controls style file
 //
 
-@use "sass:color";
-
 @use "~/abstracts/colors";
 @use "~/abstracts/controls";
 @use "~/abstracts/sizes";
@@ -59,14 +57,12 @@
             }
 
             &:not(.disabled):not([disabled]) {
-                // this rule is weaker than the rule for even lines, so it
-                // has to be enforced manually
                 &:hover:not(:focus) {
                     background: $color-hover;
                 }
 
                 &:focus {
-                    background: color.adjust($color-focus, $lightness: 10%);
+                    background: $color-focus;
                 }
             }
         }

--- a/src/style/base/_index.scss
+++ b/src/style/base/_index.scss
@@ -10,3 +10,4 @@
 @use "fonts";
 @use "icons";
 @use "sizes";
+@use "transparent";

--- a/src/style/base/_transparent.scss
+++ b/src/style/base/_transparent.scss
@@ -1,0 +1,15 @@
+//
+// Dakara Project
+//
+// Transperent elements style file
+//
+
+button.transparent {
+    background: unset;
+    border: unset;
+    color: unset;
+    cursor: pointer;
+    margin: unset;
+    padding: unset;
+    text-align: unset;
+}

--- a/src/style/components/_header.scss
+++ b/src/style/components/_header.scss
@@ -33,6 +33,14 @@ $header-height: sizes.$row-height;
         a {
             color: inherit;
             text-decoration: none;
+
+            &:hover:not(:focus) {
+                color: colors.$neutral-clear-light;
+            }
+
+            &:focus {
+                color: colors.$neutral-clear-lighter;
+            }
         }
     }
 }

--- a/src/style/components/generics/_form.scss
+++ b/src/style/components/generics/_form.scss
@@ -331,7 +331,6 @@ $form-field-height: sizes.$row-height;
         // controls inside inputs
         .input .controls .control {
             // no margin when stacking controls
-            background: transparent;
             margin: 0;
 
             &:hover:not(:focus) {

--- a/src/style/components/generics/_form.scss
+++ b/src/style/components/generics/_form.scss
@@ -329,14 +329,17 @@ $form-field-height: sizes.$row-height;
         }
 
         // controls inside inputs
-        .input .controls {
+        .input .controls .control {
             // no margin when stacking controls
-            .control {
-                margin-right: 0;
+            background: transparent;
+            margin: 0;
+
+            &:hover:not(:focus) {
+                color: colors.$neutral-mid;
             }
 
-            .icon {
-                font-size: 1.1em;
+            &:focus {
+                color: colors.$neutral-mid-light;
             }
         }
 

--- a/src/style/components/generics/_tab_bar.scss
+++ b/src/style/components/generics/_tab_bar.scss
@@ -52,7 +52,7 @@ $tab-bar-icon-font-size: 1.25em;
             @include preboot.text-truncate();
 
             background: colors.$neutral-mid;
-            color: inherit;
+            color: colors.$neutral-clear;
             cursor: pointer;
             height: $tab-bar-height;
             line-height: $tab-bar-height;
@@ -84,6 +84,7 @@ $tab-bar-icon-font-size: 1.25em;
         &:hover:not(.active),
         &:focus:not(.active) {
             background: colors.$neutral-mid-lighter;
+            color: inherit;
         }
 
         .icon {

--- a/src/style/components/karaoke/_player.scss
+++ b/src/style/components/karaoke/_player.scss
@@ -81,7 +81,14 @@ $player-progressbar-height: 0.4rem;
                     cursor: pointer;
                     min-height: $player-controls-height;
                     overflow: hidden;
-                    transition: all 0.3s ease-out;
+                }
+
+                &:hover:not(:focus) {
+                    color: colors.$brand-primary-lighter;
+                }
+
+                &:focus {
+                    color: colors.$brand-primary-lighter;
                 }
 
                 .song-title {

--- a/src/style/components/karaoke/_playlist_info_bar.scss
+++ b/src/style/components/karaoke/_playlist_info_bar.scss
@@ -41,7 +41,11 @@ $playlist-info-bar-height-smartphone: 7rem;
         text-decoration: none;
     }
 
-    &:hover {
+    &:hover:not(:focus) {
+        background: colors.$brand-primary-lighter;
+    }
+
+    &:focus {
         background: colors.$brand-primary-lighter;
     }
 

--- a/src/style/components/library/_song.scss
+++ b/src/style/components/library/_song.scss
@@ -6,6 +6,7 @@
 
 @use "~/thirdparty/preboot";
 
+@use "~/abstracts/colors";
 @use "~/abstracts/sizes";
 @use "~/abstracts/support";
 
@@ -34,22 +35,39 @@
             flex-direction: column;
         }
 
-        // `song` subclass: the song itself.
-        .song {
+        .expander {
+            background: unset;
+            border: 0;
+            color: unset;
             cursor: pointer;
             flex: 1;
-            min-height: sizes.$row-height;
+            margin: 0;
+            padding: 0;
+            text-align: unset;
 
-            .general {
-                @include sizes.make-vertical-row-padding(horizontal);
+            &:focus {
+                background: colors.$neutral-mid-lighter;
 
-                @include support.make-smartphone {
-                    align-items: initial;
-                    flex-direction: column;
+                .song .duration {
+                    background: colors.$neutral-clear-lighter;
+                }
+            }
 
-                    .artist-work {
-                        @include support.make-smartphone {
-                            display: none;
+            // `song` subclass: the song itself.
+            .song {
+                min-height: sizes.$row-height;
+
+                .general {
+                    @include sizes.make-vertical-row-padding(horizontal);
+
+                    @include support.make-smartphone {
+                        align-items: initial;
+                        flex-direction: column;
+
+                        .artist-work {
+                            @include support.make-smartphone {
+                                display: none;
+                            }
                         }
                     }
                 }

--- a/src/style/components/library/_song.scss
+++ b/src/style/components/library/_song.scss
@@ -36,14 +36,7 @@
         }
 
         .expander {
-            background: unset;
-            border: 0;
-            color: unset;
-            cursor: pointer;
             flex: 1;
-            margin: 0;
-            padding: 0;
-            text-align: unset;
 
             &:focus {
                 background: colors.$neutral-mid-lighter;

--- a/src/style/components/library/_song.scss
+++ b/src/style/components/library/_song.scss
@@ -37,6 +37,7 @@
 
         .expander {
             flex: 1;
+            overflow-y: hidden;
 
             &:focus {
                 background: colors.$neutral-mid-lighter;

--- a/src/style/layout/_listing.scss
+++ b/src/style/layout/_listing.scss
@@ -65,8 +65,7 @@ $listing-entry-control-icon-size: sizes.$row-icon-font-size;
         // can be applied to the listing-entry itself or any of its children
         .hoverizable,
         &.hoverizable {
-            &:hover,
-            &:focus {
+            &:hover {
                 background: colors.$neutral-mid-lighter;
             }
         }


### PR DESCRIPTION
At least, give a feedback when something is selected on keyboard:

- Controls (same color as highlight at the moment);
- Controls inside an input (search bar);
- Links;
- Link in the header;
- Song in song library;
- Song in player.

Note that the faked inputs (i.e. the search bar), which have a dissociated styled element, are still reported to not have focus styling.