### PR TITLE
Fix listing padding on smarphones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 
 - Fixed tabs padding for smartphones.
 - Fixed notification control font size.
+- Fixed listing padding for smartphones.
 
 ## 1.9.0 - 2025-03-06
 

--- a/src/style/layout/_box.scss
+++ b/src/style/layout/_box.scss
@@ -187,12 +187,12 @@ $ribbon-control-height: sizes.$row-height;
   // }
 
   p,
-  ul {
+  ul:not(.listing) {
     @include sizes.make-gap(margin, horizontal);
 
     // paragraphs have margin between them
     + p,
-    + ul {
+    + ul:not(.listing) {
       margin-top: 0.5em;
     }
   }


### PR DESCRIPTION
This PR fixes the horizontal padding of listings when used in a box.

This is a hotfix and a better solution may exist.