### PR TITLE
Fix padding/margin for smartphones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 
 - Fixed tabs padding for smartphones.
 - Fixed notification control font size.
+- Fixed padding/margin problems for smartphones.
 
 ## 1.9.0 - 2025-03-06
 

--- a/src/style/abstracts/_sizes.scss
+++ b/src/style/abstracts/_sizes.scss
@@ -79,12 +79,12 @@ $subrow-icon-font-size: 0.85 * $row-icon-font-size;
   }
 
   // apply the rule
-  @include support.make-smartphone {
-    #{$property}: $value-smartphone !important;
-  }
-
   & {
     #{$property}: $value;
+  }
+
+  @include support.make-smartphone {
+    #{$property}: $value-smartphone;
   }
 }
 


### PR DESCRIPTION
This PR fixes many issues with padding/margin that appear of smartphones.

When fixing Stylelint warnings in #163, the `src/style/abstracts/_sizes.scss::make-gap` mixin was modified to respect the [declarations and nested rules](https://sass-lang.com/documentation/breaking-changes/mixed-decls/) order. Doing so forced to change the order between the normal padding/margin rule and the smartphone padding/margin rule. The smartphone rule being the first but with the same CSS priority as the normal rule being the last (the media query does not give a higher priority), the smartphone rule was always ignored. It was enforced by using the `!important` keyword, which broke severa things in the design.

Actually, the two rules did not need to be reordered, as long as the normal rule is in a `:& {}` block. This PR provides this fix.