### PR TITLE
Allow bump_version script to commit with no-verify

### DIFF
--- a/bump_version.sh
+++ b/bump_version.sh
@@ -27,7 +27,7 @@ sed -i "/^## Unreleased$/a \\
 ## $version_number - $version_date" $changelog_file
 
 git add package.json package-lock.json $changelog_file
-git commit -m "Version $version_number"
+git commit -m "Version $version_number" --no-verify
 git tag "$version_number"
 
 echo "Version bumped to $version_number"


### PR DESCRIPTION
Since #173 introduced pre-commit hooks, this PR allows `bump_version.sh` to bypass them.