### PR TITLE
Fix incorrect smartphone styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Fixed tabs padding for smartphones.
 - Fixed notification control font size.
 - Fixed padding/margin problems for smartphones.
+- Fixed incorrect smartphone styling.
 
 ## 1.9.0 - 2025-03-06
 

--- a/src/style/components/_header.scss
+++ b/src/style/components/_header.scss
@@ -21,13 +21,14 @@ $header-height: sizes.$row-height;
 
   h1 {
     @include sizes.make-gap(padding, horizontal);
-    @include support.make-smartphone {
-      font-size: x-large;
-    }
 
     & {
       font-size: xx-large;
       line-height: $header-height * 0.9;
+    }
+
+    @include support.make-smartphone {
+      font-size: x-large;
     }
 
     a {

--- a/src/style/components/generics/_form.scss
+++ b/src/style/components/generics/_form.scss
@@ -82,9 +82,6 @@ $form-field-height: sizes.$row-height;
       // `border-spacing`, but the rule is cancelled if there is a header
       // just before
       @include sizes.make-gap(margin, top, -1);
-      @include support.make-smartphone {
-        border-spacing: 0 sizes.$gap-vertical-smartphone;
-      }
 
       & {
         border-collapse: separate;
@@ -93,19 +90,23 @@ $form-field-height: sizes.$row-height;
         width: 100%;
       }
 
+      @include support.make-smartphone {
+        border-spacing: 0 sizes.$gap-vertical-smartphone;
+      }
+
       // The field contains a label and an input.
       .field {
         display: table-row;
 
         .label {
-          @include support.make-smartphone {
-            display: block !important;
-          }
-
           & {
             // this allows to shrink the label 'column' as small as
             // possible
             display: table-cell;
+          }
+
+          @include support.make-smartphone {
+            display: block;
           }
 
           & {

--- a/src/style/components/karaoke/_player.scss
+++ b/src/style/components/karaoke/_player.scss
@@ -147,9 +147,6 @@ $player-progressbar-height: 0.4rem;
       }
 
       @include sizes.make-gap(margin, right);
-      @include support.make-smartphone {
-        @include make-timing(0.7);
-      }
 
       & {
         @include make-timing(0.7);
@@ -161,6 +158,10 @@ $player-progressbar-height: 0.4rem;
         min-width: max-content;
         overflow: hidden;
         text-align: right;
+      }
+
+      @include support.make-smartphone {
+        @include make-timing(0.7);
       }
 
       .current {

--- a/src/style/components/karaoke/_playlist_info_bar.scss
+++ b/src/style/components/karaoke/_playlist_info_bar.scss
@@ -24,10 +24,6 @@ $playlist-info-bar-height-smartphone: 7rem;
 // Info don't have specific classes.
 #playlist-info-bar {
   @include sizes.make-gap(padding, horizontal);
-  @include support.make-smartphone {
-    font-size: 0.85em;
-    height: $playlist-info-bar-height-smartphone;
-  }
 
   & {
     align-items: center;
@@ -39,6 +35,11 @@ $playlist-info-bar-height-smartphone: 7rem;
     justify-content: space-between;
     overflow: hidden;
     text-decoration: none;
+  }
+
+  @include support.make-smartphone {
+    font-size: 0.85em;
+    height: $playlist-info-bar-height-smartphone;
   }
 
   &:hover:not(:focus) {

--- a/src/style/components/library/_song.scss
+++ b/src/style/components/library/_song.scss
@@ -59,9 +59,7 @@
             flex-direction: column;
 
             .artist-work {
-              @include support.make-smartphone {
-                display: none;
-              }
+              display: none;
             }
           }
         }

--- a/src/style/layout/_listing_details.scss
+++ b/src/style/layout/_listing_details.scss
@@ -36,15 +36,16 @@
 
     > .header {
       @include sizes.make-gap(padding, horizontal);
-      @include support.make-smartphone {
-        display: block;
-      }
 
       & {
         display: table-cell;
         font-weight: normal;
         vertical-align: top;
         white-space: nowrap;
+      }
+
+      @include support.make-smartphone {
+        display: block;
       }
 
       // .icon {


### PR DESCRIPTION
This PR is a follow-up of #182, which applies the same fix to all smartphone CSS rules that were moved before normal rules in #173 and were hence invalidated.